### PR TITLE
chore: enable code highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The documentation can be viewed [here](https://github.com/BenSt099/isosigns/blob
 
 ## Example
 
-```
+```tex
  %%% Example file   
     \documentclass{article}
     


### PR DESCRIPTION
I enabled the code highlighting feature for Markdown files to better read the `Tex` code.